### PR TITLE
chore: add .gitignore to ignore runtime folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# --- Runtime output ---
+Downloads/
+PDF_Output/
+logs/
+*.log
+*.pdf
+
+# --- Python cruft ---
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+dist/
+build/
+*.egg-info/
+pip-wheel-metadata/
+
+# --- Virtual env ---
+.venv/
+venv/
+env/
+
+# --- IDE ---
+.vscode/
+.idea/


### PR DESCRIPTION
- Bỏ qua các thư mục sinh ra khi chạy (Downloads, PDF_Output, logs)
- Giúp repo nhẹ và sạch hơn, tránh commit file tạm
